### PR TITLE
fix: command line args

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "pugserver",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pugserver",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MPL-2.0",
       "dependencies": {
+        "commander": "^12.1.0",
         "node-static": "^0.7.11",
         "pug": "^3.0.2"
       },
@@ -2119,6 +2120,15 @@
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/concat-map": {
@@ -10144,6 +10154,11 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="
     },
     "concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "preferGlobal": true,
   "author": "Yorick <yorick@ctrlalt.dev>",
   "dependencies": {
+    "commander": "^12.1.0",
     "node-static": "^0.7.11",
     "pug": "^3.0.2"
   },

--- a/pugserver.js
+++ b/pugserver.js
@@ -1,27 +1,35 @@
 #!/usr/bin/env node
+const { program } = require('commander')
 const http = require('http')
 const fs = require('fs')
 const path = require('path')
 const pug = require('pug')
 const staticfiles = require('node-static')
 
-const pugPath = process.argv[process.argv.length - 1]
-const port = process.argv[process.argv.findIndex(e => e === '-p') + 1] || 8080
-const fileServer = new staticfiles.Server(pugPath || '.')
+program
+  .description('Basic .pug file server')
+  .argument('[string]', 'path', '.')
+  .option('-p, --port <number>', 'run your server on port', '8080')
+  .action(startServer)
+program.parse()
 
-try {
-  http.createServer((req, res) => {
-    console.info(req.method, req.url)
+function startServer (pugPath, { port }) {
+  const fileServer = new staticfiles.Server(pugPath || '.')
+  try {
+    http.createServer((req, res) => {
+      console.info(req.method, req.url)
 
-    const requrl = req.url.match(/\/$/) ? `${req.url}index` : req.url
+      const requrl = req.url.match(/\/$/) ? `${req.url}index` : req.url
 
-    if (fs.existsSync(path.join(pugPath, `${requrl}.pug`))) {
-      res.writeHead(200, { 'Content-Type': 'text/html' })
-      res.end(pug.renderFile(path.join(pugPath, `${requrl}.pug`)))
-    } else {
-      req.addListener('end', () => { fileServer.serve(req, res) }).resume()
-    }
-  }).listen(port)
-} catch (e) {
-  throw new Error(e)
+      if (fs.existsSync(path.join(pugPath, `${requrl}.pug`))) {
+        res.writeHead(200, { 'Content-Type': 'text/html' })
+        res.end(pug.renderFile(path.join(pugPath, `${requrl}.pug`)))
+      } else {
+        req.addListener('end', () => { fileServer.serve(req, res) }).resume()
+      }
+    }).listen(port)
+    console.log(`Open your browser to http://localhost:${port}/`)
+  } catch (e) {
+    throw new Error(e)
+  }
 }


### PR DESCRIPTION
A convenient tool for me, thank you!
But if I specify the path to the directory (ex `pugserver html/`), an error occurs:

```
Error: listen EADDRINUSE: address already in use /usr/bin/node
    at Server.setupListenHandle [as _listen2] (node:net:1881:21)
    at listenInCluster (node:net:1946:12)
    at Server.listen (node:net:2061:5)
    at Object.<anonymous> (/mnt/data/Develope/qq-webcomponent-vs-iframe/node_modules/.pnpm/pugserver@1.1.1/node_modules/pugserver/pugserver.js:24:6)
    at Module._compile (node:internal/modules/cjs/loader:1434:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1518:10)
    at Module.load (node:internal/modules/cjs/loader:1249:32)
    at Module._load (node:internal/modules/cjs/loader:1065:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:158:12)
    at node:internal/main/run_main_module:30:49
Emitted 'error' event on Server instance at:
    at emitErrorNT (node:net:1925:8)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  code: 'EADDRINUSE',
  errno: -98,
  syscall: 'listen',
  address: '/usr/bin/node',
  port: -1
}
```
because the variables take these values `{ port: '/usr/bin/node', pugPath: 'html/' }`.

I made the following changes:

* Add commander package
* Move code to `startServer` function

Now arguments can be passed in any order and the arguments still have their default values.